### PR TITLE
Tweaks and fixes for view-partials

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,14 @@ var fs = require('fs');
 
 var fileCache = {};
 
+function fixExtension(filename) {
+  if (filename.indexOf('.html') === -1) {
+    filename += '.html';
+  }
+
+  return filename;
+}
+
 module.exports = function(path, options, callback) {
   var key = path + ':thulium:string';
 
@@ -32,7 +40,7 @@ module.exports = function(path, options, callback) {
   options.partial = options.renderPartial = function renderPartial(partialPath, locals) {
     try {
 
-      var partialFile = fs.readFileSync('./' + options.settings.views + '/' + partialPath, 'utf8');
+      var partialFile = fs.readFileSync('./' + options.settings.views + '/' + fixExtension(partialPath), 'utf8');
 
       var partialTemplate = new Thulium({
         template : partialFile
@@ -54,7 +62,7 @@ module.exports = function(path, options, callback) {
   if (options.layout !== false) {
     var layoutView;
 
-    var layoutPath = './' + options.settings.views + '/layouts/' + options.layout + '.html';
+    var layoutPath = './' + options.settings.views + '/layouts/' + fixExtension(options.layout);
 
     var layoutKey = layoutPath + ':thulium:string';
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function(path, options, callback) {
 
   var tm;
 
-  options.renderPartial = function(partialPath, locals) {
+  options.renderPartial = function renderPartial(partialPath, locals) {
     try {
 
       var partialFile = fs.readFileSync('./' + options.settings.views + '/' + partialPath, 'utf8');
@@ -39,6 +39,7 @@ module.exports = function(path, options, callback) {
       });
 
       locals = locals || {};
+      locals.renderPartial = renderPartial;
 
       partialTemplate.parseSync().renderSync(locals);
 
@@ -48,7 +49,7 @@ module.exports = function(path, options, callback) {
       return callback(err);
     }
 
-  }
+  };
 
   if (options.layout !== false) {
     var layoutView;

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function(path, options, callback) {
 
   var tm;
 
-  options.renderPartial = function renderPartial(partialPath, locals) {
+  options.partial = options.renderPartial = function renderPartial(partialPath, locals) {
     try {
 
       var partialFile = fs.readFileSync('./' + options.settings.views + '/' + partialPath, 'utf8');
@@ -39,7 +39,7 @@ module.exports = function(path, options, callback) {
       });
 
       locals = locals || {};
-      locals.renderPartial = renderPartial;
+      locals.partial = locals.renderPartial = renderPartial;
 
       partialTemplate.parseSync().renderSync(locals);
 


### PR DESCRIPTION
I just made three simple tweaks for partial rendering support:
- adds the `.html` extension only if missing, e.g. `renderPartial('foo') => foo.html`
- adds `partial()` alias as  shorter version of `renderPartial()`
- also inject both helpers on each partials' locals
